### PR TITLE
fixing dynamic response form issue, presentation of data in table format and Adding share form link.

### DIFF
--- a/app/helpers/g_forms_helper.rb
+++ b/app/helpers/g_forms_helper.rb
@@ -6,4 +6,24 @@ module GFormsHelper
   def find_question(question_id)
     Question.find(question_id).title
   end
+
+  def display_answer(question_id, answer)
+    question = find_question(question_id)
+    if question.type_of_question == 'multiselect'
+      display_multiselect_answer(answer)
+    elsif question.type_of_question == 'radio_button'
+      display_radio_button_answer(answer)
+    else
+      answer
+    end
+  end
+
+  def display_multiselect_answer(answer)
+    options = Option.where(id: answer)
+    options.map(&:title).join(', ')
+  end
+
+  def display_radio_button_answer(answer)
+    Option.find(answer).title
+  end
 end

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -9,13 +9,15 @@ module ResponsesHelper
       options = Option.where(id: answer)
       options.map(&:title).join(', ')
     elsif question.type_of_question == 'radio_button'
-      Option.find(answer).title
+      Option.find_by(id: answer)&.title || answer
     else
       answer
     end
   end
 
   def render_question_options(question)
+    return render_text_field(question) if question.options.empty?
+
     case question.type_of_question
     when 'multiselect'
       render_multiselect_options(question)

--- a/app/helpers/responses_helper.rb
+++ b/app/helpers/responses_helper.rb
@@ -1,0 +1,60 @@
+module ResponsesHelper
+  def find_question(question_id)
+    Question.find(question_id).title
+  end
+
+  def display_answer(question_id, answer)
+    question = Question.find(question_id)
+    if question.type_of_question == 'multiselect'
+      options = Option.where(id: answer)
+      options.map(&:title).join(', ')
+    elsif question.type_of_question == 'radio_button'
+      Option.find(answer).title
+    else
+      answer
+    end
+  end
+
+  def render_question_options(question)
+    case question.type_of_question
+    when 'multiselect'
+      render_multiselect_options(question)
+    when 'radio_button'
+      render_radio_button_options(question)
+    when 'text'
+      render_text_field(question)
+    when 'text_area'
+      render_text_area(question)
+    else
+      ''
+    end
+  end
+
+  private
+
+  def render_multiselect_options(question)
+    options_html = question.options.map do |option|
+      checkbox_tag = check_box_tag "response[answers][#{question.id}][]", option.id, false, id: "response_#{question.id}_#{option.id}"
+      label_tag = label_tag "response_#{question.id}_#{option.id}", option.title, for: "response_#{question.id}_#{option.id}"
+      content_tag(:div, checkbox_tag + label_tag)
+    end
+    options_html.join('').html_safe
+  end
+
+  def render_radio_button_options(question)
+    options_html = question.options.map do |option|
+      radio_button_tag = radio_button_tag "response[answers][#{question.id}]", option.id, false, id: "response_#{question.id}_#{option.id}"
+      label_tag = label_tag "response_#{question.id}_#{option.id}", option.title, for: "response_#{question.id}_#{option.id}"
+      content_tag(:div, radio_button_tag + label_tag)
+    end
+    options_html.join('').html_safe
+  end
+
+  def render_text_field(question)
+    text_field_tag "response[answers][#{question.id}]", nil
+  end
+
+  def render_text_area(question)
+    text_area_tag "response[answers][#{question.id}]", nil
+  end
+end

--- a/app/views/g_forms/_form.html.erb
+++ b/app/views/g_forms/_form.html.erb
@@ -32,7 +32,7 @@
     <% end %>
   </div>
   <div class="links">
-    <%= link_to_add_association "add questions", form, :questions, form_name: 'form', data: {association_insertion_node: '.questions', association_insertion_method: :append} %>
+    <%= link_to_add_association "add questions", form, :questions, form_name: 'form' %>
   </div>
 
   <div>

--- a/app/views/g_forms/_g_form.html.erb
+++ b/app/views/g_forms/_g_form.html.erb
@@ -1,29 +1,26 @@
-<div id="<%= dom_id g_form %>">
-  <p>
-    <strong>Form Title:</strong>
-    <%= g_form.title %>
-  </p>
+<h1><%= g_form.title %></h1>
+<p><%= g_form.description %></p>
 
-  <p>
-    <strong>Form Description:</strong>
-    <%= g_form.description %><br>
-  </p>
+<%= link_to 'Share Form', new_g_form_response_path(g_form) %>
 
-    <p>
-    <strong>Form image:</strong>
-    <%= g_form.image.attached? ? image_tag(g_form.image) : '' %>
-  </p>
-  <h2>Questions</h2>
-  <div>
-    <% g_form.questions.each do |question| %>
-      <br>
-      Question: <%= question.title %><br>
-      Image: <%= question.image.attached? ? image_tag(question.image) : '' %><br>
-      Type: <%= question.type_of_question %><br>
-      <% question.options.each do |option| %>
-      <%= option.title %><br>
+<h2>Responses</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Respondent</th>
+      <% g_form.questions.each do |question| %>
+        <th>Question : <%= question.title %></th>
       <% end %>
+    </tr>
+  </thead>
+  <tbody>
+    <% g_form.responses.each do |response| %>
+      <tr>
+        <td><%= response.sent_by %></td>
+        <% response.answers.each do |question_id, answer| %>
+          <td><%= display_answer(question_id, answer) %></td>
+        <% end %>
+      </tr>
     <% end %>
-  </div>
-
-</div>
+  </tbody>
+</table>

--- a/app/views/g_forms/_question_fields.html.erb
+++ b/app/views/g_forms/_question_fields.html.erb
@@ -1,21 +1,21 @@
 <div class="nested-fields">
-	<%= form.label :title %>
-	<%= form.text_field :title %>
+  <%= form.label :title %>
+  <%= form.text_field :title %>
 
-	<%= form.label :type_of_question %>
-	<%= form.select(:type_of_question, options_for_select([["Text"]])) %>
+  <%= form.label :type_of_question %>
+  <%= form.select :type_of_question, [['Radio button', 'radio_button'], ['Multiselect', 'multiselect'], ['Text', 'text'], ['Text area', 'text_area']], {} %>
 
-	<%= form.label :image %>
-	<%= form.file_field :image %>
+  <%= form.label :image %>
+  <%= form.file_field :image %>
 
-	<h4>Options</h4>
-	<div id="options">
-			<%= form.fields_for :options do |option_form| %>
-					<%= render 'option_fields', form: option_form %>
-			<% end %>
-			<div class="links">
-					<%= link_to_add_association 'Add Option', form, :options, form_name: 'form' %>
-			</div>
-	</div>
-	<%= link_to_remove_association "remove question", form %>
+  <h4>Options</h4>
+  <div id="options">
+    <%= form.fields_for :options do |option_form| %>
+      <%= render 'option_fields', form: option_form, type_of_question: form.object.type_of_question %>
+    <% end %>
+    <div class="links">
+      <%= link_to_add_association 'Add Option', form, :options, form_name: 'form', data: { type_of_question: '' } %>
+    </div>
+  </div>
+  <%= link_to_remove_association "remove question", form %>
 </div>

--- a/app/views/responses/_response.html.erb
+++ b/app/views/responses/_response.html.erb
@@ -1,11 +1,24 @@
 <div>
   <h3>Response from <%= response.sent_by %></h3>
-	<% response.answers.each do |question_id, option_ids| %>
-		<div>
-			<strong><%= find_question(question_id) %>:</strong>
-			<% option_ids.each do |option_id| %>
-				<p><%= find_option(option_id) %></p>
-			<% end %>
-		</div>
-	<% end %>
+  <table>
+    <thead>
+      <tr>
+        <th>Question</th>
+        <th>Answer</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% response.answers.each do |question_id, answer| %>
+        <tr>
+          <td><%= find_question(question_id) %></td>
+          <td><%= display_answer(question_id, answer) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
 </div>
+
+<%= link_to "Back to g forms", g_forms_path %> |
+
+
+

--- a/app/views/responses/new.html.erb
+++ b/app/views/responses/new.html.erb
@@ -5,14 +5,9 @@
   <% @form.questions.each do |question| %>
     <div>
       <h4><%= question.title %></h4>
-      <% question.options.each do |option| %>
-        <div>
-          <%= label_tag "response[answers][#{question.id}][]", option.title %>
-          <%= check_box_tag "response[answers][#{question.id}][]", option.id %>
-        </div>
-      <% end %>
+      <%= render_question_options(question) %>
     </div>
   <% end %>
 
-  <%= form.submit %>
+  <%= form.submit 'Submit Response' %>
 <% end %>


### PR DESCRIPTION
**Notes About the PR:**
1. Adding a button for sharing the form link.
2. The response form is now dynamic so the questions will be shown as per its type.(e.g. if the question type is radio button then it will display all its options in radio button and same with multiselect, text, and text field).
3. Adding a table format for listing of responses.
4. Now if question doesn't contains any options then the text field will be the default input option.

**Issues**:
1. I am still not able to resolve the jQuery issue of cocoon gem with rails 7 and therefore I couldn't add "Hidden/Show" functionality based on question type because I need to add JavaScript on cocoon form itself for this kind of functionality.
2. Questions are not editable is also a part of jQuery issue of cocoon gem I guess, because it is not displaying question_fields on edit action. I've checked with rails 6 version and i see no difference at the code level.